### PR TITLE
Feature no omnijack call when package_url defined

### DIFF
--- a/libraries/provider_chef_dk.rb
+++ b/libraries/provider_chef_dk.rb
@@ -61,7 +61,9 @@ class Chef
         metadata.yolo && Chef::Log.warn('Using a ChefDk package not ' \
                                         'officially supported on this platform')
         remote_file.run_action(:create)
-        global_shell_init(:create).write_file
+        unless node['platform'] == 'windows'
+          global_shell_init(:create).write_file
+        end
         package.run_action(:install)
         new_resource.installed = true
       end
@@ -70,7 +72,9 @@ class Chef
       # Uninstall the ChefDk package and delete the cached file
       #
       def action_remove
-        global_shell_init(:delete).write_file
+        unless node['platform'] == 'windows'
+          global_shell_init(:delete).write_file
+        end
         package.run_action(:remove)
         remote_file.run_action(:delete)
         # A full uninstall would also delete the omnijack gem, but ehhh...

--- a/libraries/provider_chef_dk.rb
+++ b/libraries/provider_chef_dk.rb
@@ -57,9 +57,11 @@ class Chef
       # Download and install the ChefDk package
       #
       def action_install
-        omnijack_gem.run_action(:install)
-        metadata.yolo && Chef::Log.warn('Using a ChefDk package not ' \
+        if new_resource.package_url.nil?
+          omnijack_gem.run_action(:install)
+          metadata.yolo && Chef::Log.warn('Using a ChefDk package not ' \
                                         'officially supported on this platform')
+        end
         remote_file.run_action(:create)
         unless node['platform'] == 'windows'
           global_shell_init(:create).write_file


### PR DESCRIPTION
Most of the time we are installing from a local artifact repository. This change eliminates the external api call when the package_url is defined. 

The global_shell_init method was failing on Windows so I added a platform check and skip the call on Windows. After making the changes, RuboCop complained the action_install method had to many lines. I tried moving the unless to the same line as the global_shell_init method but then it complained the line was to long.