### PR TITLE
#48 + assorted boilerplate build fixes

### DIFF
--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -5,7 +5,12 @@ platforms:
   - name: ubuntu-14-04-x64
   - name: ubuntu-12-04-x64
   - name: debian-7-0-x64
+  # The Debian 6 Digital Ocean image doesn't have sudo installed
   - name: debian-6-0-x64
+    provisioner:
+      sudo_command:
+    verifier:
+      sudo_command:
   - name: centos-6-5-x64
   - name: macosx
     driver:

--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -4,6 +4,9 @@ driver:
 platforms:
   - name: ubuntu-14-04-x64
   - name: ubuntu-12-04-x64
-# - name: debian-7-0-x64
-# - name: debian-6-0-x64
+  - name: debian-7-0-x64
+  - name: debian-6-0-x64
   - name: centos-6-5-x64
+  - name: macosx
+    driver:
+      name: localhost

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,12 +8,19 @@ provisioner:
 platforms:
   - name: ubuntu-14.04
   - name: ubuntu-12.04
-  - name: debian-7.6
+  - name: debian-7.8
   - name: debian-6.0.10
-  - name: centos-6.5
-  - name: macosx-10.8
-  - name: macosx-10.9
+  - name: centos-6.6
+  # - name: macosx-10.8
+  # - name: macosx-10.9
   - name: macosx-10.10
+    driver:
+      box: roboticcheese/macosx-10.10
+      ssh:
+        insert_key: false
+  - name: windows-2012
+    driver:
+      box: roboticcheese/windows-2012
 
 suites:
   - name: default
@@ -33,12 +40,13 @@ suites:
         package_url: https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chefdk_0.3.4-1_amd64.deb
     excludes:
       - ubuntu-12.04
-      - debian-7.6
+      - debian-7.8
       - debian-6.0.10
-      - centos-6.5
-      - macosx-10.8
-      - macosx-10.9
+      - centos-6.6
+      - macosx-10.10
+      - windows-2012
       - ubuntu-12-04-x64
       - debian-7-0-x64
       - debian-6-0-x64
       - centos-6-5-x64
+      - macosx

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,0 @@
-SingleSpaceBeforeFirstArg:
-  Exclude:
-    - "**/metadata.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ before_script:
   - echo -e $DIGITALOCEAN_SSH_KEY_BODY > ~/.ssh/id_rsa
 
 script:
-  - chef exec bundle exec rspec --default-path test/integration/global_shell_init/serverspec -f d && chef exec rake
+  - chef exec rake && chef exec rake kitchen:all
 
 after_script:
-  - chef exec bundle exec kitchen destroy
+  - chef exec kitchen destroy
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - echo -e $DIGITALOCEAN_SSH_KEY_BODY > ~/.ssh/id_rsa
 
 script:
-  - chef exec rake && chef exec rake kitchen:all
+  - chef exec rake && chef exec kitchen test -c 4
 
 after_script:
   - chef exec kitchen destroy

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,5 @@
 # Encoding: UTF-8
 
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 metadata

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+Kindle Cookbook Contributor Code of Conduct
+===========================================
+
+As contributors and maintainers of this project, we pledge to respect all
+people who contribute through reporting issues, posting feature requests,
+updating documentation, submitting pull requests or patches, and other
+activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual
+language or imagery, derogatory comments or personal attacks, trolling, public
+or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct. Project maintainers who do not
+follow the Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening an issue or contacting one or more of the project
+maintainers.
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](http://contributor-covenant.org), version 1.0.0,
+available [here](http://contributor-covenant.org/version/1/0/0/).

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 group :development do
   gem 'yard-chef'
   gem 'guard'
+  gem 'guard-foodcritic'
   gem 'guard-rspec'
   gem 'guard-kitchen'
 end
@@ -15,8 +16,6 @@ group :test do
   gem 'countloc'
   gem 'rubocop'
   gem 'foodcritic'
-  # TODO: guard-foodcritic has a dep conflict with Berkshelf 3
-  # gem 'guard-foodcritic'
   gem 'rspec', '>= 3'
   gem 'chefspec', '>= 4'
   gem 'simplecov'
@@ -25,7 +24,9 @@ group :test do
   gem 'fauxhai'
   gem 'test-kitchen'
   gem 'kitchen-digitalocean', '>= 0.8.0'
+  gem 'kitchen-localhost'
   gem 'kitchen-vagrant'
+  gem 'winrm-transport'
 end
 
 group :integration do

--- a/Guardfile
+++ b/Guardfile
@@ -1,15 +1,16 @@
 # Encoding: UTF-8
 
 guard :rspec, all_on_start: true, notification: false do
-  watch(/^spec\/.+_spec\.rb$/)
+  watch(%r{^spec/.+_spec\.rb$})
   watch('spec/spec_helper.rb')  { 'spec' }
 
-  watch(/^recipes\/(.+)\.rb$/) { |m| "spec/#{m[1]}_spec.rb" }
-  watch(/^attributes\/(.+)\.rb$/)
-  watch(/^files\/(.+)/)
-  watch(/^templates\/(.+)/)
-  watch(/^providers\/(.+)\.rb/)
-  watch(/^resources\/(.+)\.rb/)
+  watch(%r{^recipes/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^attributes/(.+)\.rb$})
+  watch(%r{^files/(.+)})
+  watch(%r{^templates/(.+)})
+  watch(%r{^providers/(.+)\.rb})
+  watch(%r{^resources/(.+)\.rb})
+  watch(%r{^libraries/(.+)\.rb})
 end
 
 # guard :foodcritic, cookbook_paths: '.', cli: '-t ~FC023 -f any' do

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Chef-DK Cookbook
 ================
-[![Cookbook Version](http://img.shields.io/cookbook/v/chef-dk.svg)][cookbook]
-[![Build Status](http://img.shields.io/travis/RoboticCheese/chef-dk-chef.svg)][travis]
-[![Code Climate](http://img.shields.io/codeclimate/github/RoboticCheese/chef-dk-chef.svg)][codeclimate]
-[![Coverage Status](http://img.shields.io/coveralls/RoboticCheese/chef-dk-chef.svg)][coveralls]
+[![Cookbook Version](https://img.shields.io/cookbook/v/chef-dk.svg)][cookbook]
+[![Build Status](https://img.shields.io/travis/RoboticCheese/chef-dk-chef.svg)][travis]
+[![Code Climate](https://img.shields.io/codeclimate/github/RoboticCheese/chef-dk-chef.svg)][codeclimate]
+[![Coverage Status](https://img.shields.io/coveralls/RoboticCheese/chef-dk-chef.svg)][coveralls]
 
-[cookbook]: https://supermarket.getchef.com/cookbooks/chef-dk
-[travis]: http://travis-ci.org/RoboticCheese/chef-dk-chef
+[cookbook]: https://supermarket.chef.io/cookbooks/chef-dk
+[travis]: https://travis-ci.org/RoboticCheese/chef-dk-chef
 [codeclimate]: https://codeclimate.com/github/RoboticCheese/chef-dk-chef
 [coveralls]: https://coveralls.io/r/RoboticCheese/chef-dk-chef
 
@@ -28,7 +28,7 @@ that is used for installation under Windows. _This cookbook will not run on
 Windows under earlier versions of Chef._
 
 This cookbook consumes the
-[dmg cookbook](http://supermarket.getchef.com/cookbooks/dmg) in order to
+[dmg cookbook](https://supermarket.chef.io/cookbooks/dmg) in order to
 support OS X installs. That cookbook's limitations, such as the inability
 to upgrade or uninstall packages, are thus present in the OS X implementation
 here.
@@ -141,7 +141,7 @@ License & Authors
 =================
 - Author: Jonathan Hartman <j@p4nt5.com>
 
-Copyright 2014, Jonathan Hartman
+Copyright 2014-2015, Jonathan Hartman
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Rakefile
+++ b/Rakefile
@@ -20,14 +20,6 @@ task :loc do
   Kernel.system 'countloc -r .'
 end
 
-desc 'Run knife cookbook syntax test'
-task :cookbook_test do
-  path = File.expand_path('../..', __FILE__)
-  cb = File.basename(File.expand_path('..', __FILE__))
-  Kernel.system "knife cookbook test -c test/knife.rb -o #{path} #{cb}"
-  $CHILD_STATUS == 0 || fail('Cookbook syntax check failed!')
-end
-
 FoodCritic::Rake::LintTask.new do |f|
   f.options = { fail_tags: %w(any) }
 end
@@ -38,4 +30,4 @@ Kitchen::RakeTasks.new
 
 Stove::RakeTask.new
 
-task default: %w(cane rubocop loc cookbook_test foodcritic spec kitchen:all)
+task default: %w(cane rubocop loc foodcritic spec)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: chef-dk
 # Attributes:: default
 #
-# Copyright 2014, Jonathan Hartman
+# Copyright 2014-2015 Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,9 +1,9 @@
 # Encoding: UTF-8
 #
 # Cookbook Name:: chef-dk
-# Spec:: support/matchers/chef_dk
+# Library:: matchers
 #
-# Copyright (C) 2014, Jonathan Hartman
+# Copyright (C) 2014-2015 Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,21 +17,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'spec_helper'
+if defined?(ChefSpec)
+  ChefSpec.define_matcher(:chef_dk)
 
-module ChefSpec
-  module API
-    # Some simple matchers for the chef_dk resource
-    #
-    # @author Jonathan Hartman <j@p4nt5.com>
-    module ChefDkMatchers
-      ChefSpec.define_matcher :chef_dk
-
-      def install_chef_dk(resource_name)
-        ChefSpec::Matchers::ResourceMatcher.new(:chef_dk,
-                                                :install,
-                                                resource_name)
-      end
-    end
+  def install_chef_dk(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:chef_dk, :install, name)
   end
 end

--- a/libraries/provider_chef_dk.rb
+++ b/libraries/provider_chef_dk.rb
@@ -57,9 +57,12 @@ class Chef
       # Download and install the ChefDk package
       #
       def action_install
-        omnijack_gem.run_action(:install)
-        metadata.yolo && Chef::Log.warn('Using a ChefDk package not ' \
-                                        'officially supported on this platform')
+        if new_resource.package_url.nil?
+          omnijack_gem.run_action(:install)
+          metadata.yolo && Chef::Log.warn(
+            'Using a ChefDk package not officially supported on this platform'
+          )
+        end
         remote_file.run_action(:create)
         node['platform'] == 'windows' || global_shell_init(:create).write_file
         package.run_action(:install)

--- a/libraries/provider_chef_dk.rb
+++ b/libraries/provider_chef_dk.rb
@@ -61,7 +61,7 @@ class Chef
         metadata.yolo && Chef::Log.warn('Using a ChefDk package not ' \
                                         'officially supported on this platform')
         remote_file.run_action(:create)
-        global_shell_init(:create).write_file
+        node['platform'] == 'windows' || global_shell_init(:create).write_file
         package.run_action(:install)
         new_resource.installed = true
       end
@@ -70,7 +70,7 @@ class Chef
       # Uninstall the ChefDk package and delete the cached file
       #
       def action_remove
-        global_shell_init(:delete).write_file
+        node['platform'] == 'windows' || global_shell_init(:delete).write_file
         package.run_action(:remove)
         remote_file.run_action(:delete)
         # A full uninstall would also delete the omnijack gem, but ehhh...

--- a/libraries/provider_chef_dk.rb
+++ b/libraries/provider_chef_dk.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: chef-dk
 # Library:: provider_chef_dk
 #
-# Copyright 2014, Jonathan Hartman
+# Copyright 2014-2015 Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/provider_chef_dk_debian.rb
+++ b/libraries/provider_chef_dk_debian.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: chef-dk
 # Library:: provider_chef_dk_debian
 #
-# Copyright 2014, Jonathan Hartman
+# Copyright 2014-2015 Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/provider_chef_dk_mac_os_x.rb
+++ b/libraries/provider_chef_dk_mac_os_x.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: chef-dk
 # Library:: provider_chef_dk_mac_os_x
 #
-# Copyright 2014, Jonathan Hartman
+# Copyright 2014-2015 Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/provider_chef_dk_rhel.rb
+++ b/libraries/provider_chef_dk_rhel.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: chef-dk
 # Library:: provider_chef_dk_rhel
 #
-# Copyright 2014, Jonathan Hartman
+# Copyright 2014-2015 Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/provider_chef_dk_windows.rb
+++ b/libraries/provider_chef_dk_windows.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: chef-dk
 # Library:: provider_chef_dk_windows
 #
-# Copyright 2014, Jonathan Hartman
+# Copyright 2014-2015 Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/resource_chef_dk.rb
+++ b/libraries/resource_chef_dk.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: chef-dk
 # Library:: resource_chef_dk
 #
-# Copyright 2014, Jonathan Hartman
+# Copyright 2014-2015 Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,6 @@
 # Encoding: UTF-8
-
+#
+# rubocop:disable SingleSpaceBeforeFirstArg
 name             'chef-dk'
 maintainer       'Jonathan Hartman'
 maintainer_email 'j@p4nt5.com'
@@ -17,3 +18,4 @@ supports         'debian', '>= 6.0'
 end
 supports         'mac_os_x', '>= 10.8'
 supports         'windows'
+# rubocop:enable SingleSpaceBeforeFirstArg

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: chef-dk
 # Recipe:: default
 #
-# Copyright 2014, Jonathan Hartman
+# Copyright 2014-2015 Jonathan Hartman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/libraries/provider_chef_dk_debian_spec.rb
+++ b/spec/libraries/provider_chef_dk_debian_spec.rb
@@ -1,21 +1,4 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: provider_chef_dk_debian
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 require_relative '../spec_helper'
 require_relative '../../libraries/provider_chef_dk_debian'

--- a/spec/libraries/provider_chef_dk_mac_os_x_spec.rb
+++ b/spec/libraries/provider_chef_dk_mac_os_x_spec.rb
@@ -1,21 +1,4 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: provider_chef_dk_mac_os_x
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 require_relative '../spec_helper'
 require_relative '../../libraries/provider_chef_dk_mac_os_x'

--- a/spec/libraries/provider_chef_dk_rhel_spec.rb
+++ b/spec/libraries/provider_chef_dk_rhel_spec.rb
@@ -1,21 +1,4 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: provider_chef_dk_rhel
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 require_relative '../spec_helper'
 require_relative '../../libraries/provider_chef_dk_rhel'

--- a/spec/libraries/provider_chef_dk_spec.rb
+++ b/spec/libraries/provider_chef_dk_spec.rb
@@ -1,21 +1,4 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: provider_chef_dk
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 require_relative '../spec_helper'
 require_relative '../../libraries/provider_chef_dk'

--- a/spec/libraries/provider_chef_dk_windows_spec.rb
+++ b/spec/libraries/provider_chef_dk_windows_spec.rb
@@ -1,21 +1,4 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: provider_chef_dk_windows
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 require_relative '../spec_helper'
 require_relative '../../libraries/provider_chef_dk_windows'

--- a/spec/libraries/resource_chef_dk_spec.rb
+++ b/spec/libraries/resource_chef_dk_spec.rb
@@ -1,21 +1,4 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: resource_chef_dk
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 require_relative '../spec_helper'
 require_relative '../../libraries/resource_chef_dk'

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -1,29 +1,12 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: recipes/default
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-require 'spec_helper'
+require_relative '../spec_helper'
 
 describe 'chef-dk::default' do
   let(:platform) { { platform: 'ubuntu', version: '14.04' } }
   let(:overrides) { {} }
   let(:runner) do
-    ChefSpec::ServerRunner.new(platform) do |node|
+    ChefSpec::SoloRunner.new(platform) do |node|
       overrides.each do |k, v|
         node.set['chef_dk'][k] = v
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,67 +1,28 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: spec_helper
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 require 'chef'
 require 'chefspec'
-require 'json'
 require 'tempfile'
 require 'simplecov'
 require 'simplecov-console'
 require 'coveralls'
 require 'tmpdir'
 require 'fileutils'
+require_relative '../libraries/matchers'
 require_relative 'support/provider/dmg_package'
 require_relative 'support/resource/dmg_package'
-require_relative 'support/matchers/chef_dk'
 
 RSpec.configure do |c|
   c.color = true
 
   c.before(:suite) do
-    COOKBOOK_PATH = Dir.mktmpdir 'chefspec'
+    COOKBOOK_PATH = Dir.mktmpdir('chefspec')
     metadata = Chef::Cookbook::Metadata.new
     metadata.from_file(File.expand_path('../../metadata.rb', __FILE__))
     link_path = File.join(COOKBOOK_PATH, metadata.name)
     FileUtils.ln_s(File.expand_path('../..', __FILE__), link_path)
-    c.cookbook_path = COOKBOOK_PATH
-  end
-
-  c.before(:each) do
-    # Don't worry about external cookbook dependencies
-    allow_any_instance_of(Chef::Cookbook::Metadata).to receive(:depends)
-
-    # Prep lookup() for the stubs below
-    allow_any_instance_of(Chef::ResourceCollection).to receive(:lookup)
-      .and_call_original
-
-    # Test each recipe in isolation, regardless of includes
-    @included_recipes = []
-    allow_any_instance_of(Chef::RunContext).to receive(:loaded_recipe?)
-      .and_return(false)
-    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe) do |_, i|
-      allow_any_instance_of(Chef::RunContext).to receive(:loaded_recipe?)
-        .with(i)
-        .and_return(true)
-      @included_recipes << i
-    end
-    allow_any_instance_of(Chef::RunContext).to receive(:loaded_recipes)
-      .and_return(@included_recipes)
+    c.cookbook_path = [COOKBOOK_PATH,
+                       File.expand_path('../support/cookbooks', __FILE__)]
   end
 
   c.after(:suite) { FileUtils.rm_r(COOKBOOK_PATH) }

--- a/spec/support/cookbooks/dmg/metadata.rb
+++ b/spec/support/cookbooks/dmg/metadata.rb
@@ -1,0 +1,11 @@
+# Encoding: UTF-8
+#
+# rubocop:disable SingleSpaceBeforeFirstArg
+name             'dmg'
+maintainer       'Jonathan Hartman'
+maintainer_email 'j@p4nt5.com'
+license          'Apache v2.0'
+description      'Installs/configures dmg'
+long_description 'Installs/configures dmg'
+version          '2.2.0'
+# rubocop:enable SingleSpaceBeforeFirstArg

--- a/spec/support/provider/dmg_package.rb
+++ b/spec/support/provider/dmg_package.rb
@@ -1,30 +1,13 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Provider:: dmg_package
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-require 'spec_helper'
+require_relative '../../spec_helper'
 
 class Chef
   class Provider
     # A fake dmg_package provider
     #
     # @author Jonathan Hartman <j@p4nt5.com>
-    class DmgPackage < Provider
+    class DmgPackage < Provider::LWRPBase
     end
   end
 end

--- a/spec/support/resource/dmg_package.rb
+++ b/spec/support/resource/dmg_package.rb
@@ -1,48 +1,19 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Resource:: dmg_package
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-require 'spec_helper'
+require_relative '../../spec_helper'
 
 class Chef
   class Resource
     # A fake dmg_package resource
     #
     # @author Jonathan Hartman <j@p4nt5.com>
-    class DmgPackage < Resource
-      def initialize(name, run_context = nil)
-        super
-        @resource_name = :dmg_package
-        @action = :install
-        @allowed_actions = [:install, :remove]
-      end
-
-      def app(arg = nil)
-        set_or_return(:app, arg, kind_of: String)
-      end
-
-      def source(arg = nil)
-        set_or_return(:source, arg, kind_of: String)
-      end
-
-      def type(arg = nil)
-        set_or_return(:type, arg, kind_of: String)
-      end
+    class DmgPackage < Resource::LWRPBase
+      self.resource_name = :dmg_package
+      actions [:install, :remove]
+      default_action :install
+      attribute :app, kind_of: String
+      attribute :source, kind_of: String
+      attribute :type, kind_of: String
     end
   end
 end

--- a/test/integration/default/serverspec/localhost/package_spec.rb
+++ b/test/integration/default/serverspec/localhost/package_spec.rb
@@ -1,31 +1,25 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: serverspec/localhost/package
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-require 'spec_helper'
+require_relative '../spec_helper'
 
 describe 'Chef-DK package' do
-  it 'is installed' do
-    case os[:family]
-    when 'darwin'
-      expect(package('com.getchef.pkg.chefdk')).to be_installed.by(:pkgutil)
-    else
-      expect(package('chefdk')).to be_installed
+  describe package('com.getchef.pkg.chefdk'), if: os[:family] == 'darwin' do
+    it 'is installed' do
+      expect(subject).to be_installed.by(:pkgutil)
+    end
+  end
+
+  # On Windows, the package name changes to reflect each ChefDK version
+  describe package('Chef Development Kit v*'), if: os[:family] == 'windows' do
+    it 'is installed' do
+      expect(subject).to be_installed
+    end
+  end
+
+  describe package('chefdk'),
+           if: %w(ubuntu debian redhat).include?(os[:family]) do
+    it 'is installed' do
+      expect(subject).to be_installed
     end
   end
 end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,22 +1,10 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: serverspec/spec_helper
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 require 'serverspec'
 
-set :backend, :exec
+if RUBY_PLATFORM.match(/mswin|mingw32|windows/)
+  set :os, family: 'windows'
+  set :backend, :cmd
+else
+  set :backend, :exec
+end

--- a/test/integration/global_shell_init/serverspec/localhost/environment_spec.rb
+++ b/test/integration/global_shell_init/serverspec/localhost/environment_spec.rb
@@ -1,40 +1,20 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: serverspec/localhost/environment
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-require 'spec_helper'
+require_relative '../spec_helper'
 
 describe 'Chef-DK environment' do
-  let(:bashrc_file) do
-    case os[:family]
-    when 'darwin', 'redhat'
-      '/etc/bashrc'
-    when 'ubuntu', 'debian'
-      '/etc/bash.bashrc'
-    else
-      nil
+  shared_examples_for 'file with chef shell-init' do
+    it 'contains the chef shell-init command' do
+      expect(subject.content).to match(/^eval "\$\(chef shell-init bash\)"$/)
     end
   end
 
-  describe 'bashrc file' do
-    it 'contains the chef shell-init command' do
-      matcher = /^eval "\$\(chef shell-init bash\)"$/
-      expect(file(bashrc_file).content).to match(matcher)
-    end
+  describe file('/etc/bashrc'), if: %w(darwin redhat).include?(os[:family]) do
+    it_behaves_like 'file with chef shell-init'
+  end
+
+  describe file('/etc/bash.bashrc'),
+           if: %w(ubuntu debian).include?(os[:family]) do
+    it_behaves_like 'file with chef shell-init'
   end
 end

--- a/test/integration/install_from_specific_url/serverspec/localhost/package_spec.rb
+++ b/test/integration/install_from_specific_url/serverspec/localhost/package_spec.rb
@@ -8,4 +8,10 @@ describe 'Chef-DK package' do
       expect(subject).to be_installed.with_version('0.3.4-1')
     end
   end
+
+  describe command('/opt/chef/embedded/bin/gem list omnijack') do
+    it 'does not list Omnijack as installed' do
+      expect(subject.stdout).not_to match(/^omnijack /)
+    end
+  end
 end

--- a/test/integration/install_from_specific_url/serverspec/localhost/package_spec.rb
+++ b/test/integration/install_from_specific_url/serverspec/localhost/package_spec.rb
@@ -1,26 +1,11 @@
 # Encoding: UTF-8
-#
-# Cookbook Name:: chef-dk
-# Spec:: serverspec/install_from_specific_url/package
-#
-# Copyright (C) 2014, Jonathan Hartman
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-require 'spec_helper'
+require_relative '../spec_helper'
 
 describe 'Chef-DK package' do
-  it 'is installed' do
-    expect(package('chefdk')).to be_installed.with_version('0.3.4-1')
+  describe package('chefdk') do
+    it 'is installed with the right version' do
+      expect(subject).to be_installed.with_version('0.3.4-1')
+    end
   end
 end

--- a/test/knife.rb
+++ b/test/knife.rb
@@ -1,4 +1,0 @@
-# Encoding: UTF-8
-
-cache_type 'BasicFile'
-cache_options(path: File.expand_path('../../.kitchen/.cache', __FILE__))


### PR DESCRIPTION
- Put a guard on the shell-init resource to not run on Windows (via #48)
- Don't install Omnijack or query the Omnitruck API when a package_url is provided (via #48)
- Update Kitchen config to most recent Vagrant boxes
- Move the Travis OS X testing to use kitchen-localhost
- Update assorted boilerplate stuff (add a CoC, fix new RuboCop offenses, use HTTPS on all badges, s/getchef.com/chef.io, etc.)