### PR TITLE
add wrapper support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,6 +33,12 @@ suites:
     attributes:
       chef_dk:
         global_shell_init: true
+  - name: wrappers
+    run_list:
+      - recipe[chef-dk]
+    attributes:
+      chef_dk:
+        wrappers: true
   - name: install_from_specific_url
     run_list:
       - recipe[chef-dk]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,3 +21,5 @@
 default['chef_dk']['version'] = 'latest'
 default['chef_dk']['package_url'] = nil
 default['chef_dk']['global_shell_init'] = false
+default['chef_dk']['wrappers'] = false
+default['chef_dk']['wrapper_path'] = '/usr/local/bin'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,3 +23,15 @@ chef_dk 'chef_dk' do
   package_url node['chef_dk']['package_url']
   global_shell_init node['chef_dk']['global_shell_init']
 end
+
+Dir['/opt/chefdk/bin/*'].map {|f| File.basename(f)}.each do |script|
+  template "chefdk_wrapper_#{script}" do
+    source 'chefdk_wrapper.erb'
+    path  File.join(node['chef_dk']['wrapper_path'],script)
+    owner 'root'
+    group 'root'
+    mode  '0555'
+    variables(command: script)
+    only_if { node['chef_dk']['wrappers'] }
+  end
+end

--- a/templates/default/chefdk_wrapper.erb
+++ b/templates/default/chefdk_wrapper.erb
@@ -1,0 +1,4 @@
+#!/bin/bash
+#
+eval "$(/opt/chefdk/bin/chef shell-init bash)"
+<%= @command %> "$@"


### PR DESCRIPTION
ChefDK requires you to override your ruby environment with its own.
The wrapper support allows you to install wrappers into a directory
in your path (/usr/local/bin by default) that allow you to run
ChefDK commands transparently without changing your ruby environment.