### PR TITLE
Define a minimal, :repo source only, app :upgrade action

### DIFF
--- a/libraries/resource_chef_dk_app_debian.rb
+++ b/libraries/resource_chef_dk_app_debian.rb
@@ -62,6 +62,28 @@ class Chef
       end
 
       #
+      # Upgrade or install the Chef-DK. This action currently only supports the
+      # :repo installation source.
+      #
+      action :upgrade do
+        case new_resource.source
+        when :direct
+          raise(Chef::Exceptions::UnsupportedAction,
+                'Direct installs do not support the :upgrade action')
+        when :repo
+          package 'apt-transport-https'
+          include_recipe "apt-chef::#{new_resource.channel}"
+          package 'chefdk' do
+            version new_resource.version unless new_resource.version.nil?
+            action :upgrade
+          end
+        else
+          raise(Chef::Exceptions::UnsupportedAction,
+                'Custom installs do not support the :upgrade action')
+        end
+      end
+
+      #
       # The APT repository is shared between Chef, Chef-DK, etc. so all we can
       # confidently do for removal is to remove the package.
       #

--- a/libraries/resource_chef_dk_app_rhel.rb
+++ b/libraries/resource_chef_dk_app_rhel.rb
@@ -62,6 +62,27 @@ class Chef
       end
 
       #
+      # Upgrade or install the Chef-DK. This action currently only supports the
+      # :repo installation source.
+      #
+      action :upgrade do
+        case new_resource.source
+        when :direct
+          raise(Chef::Exceptions::UnsupportedAction,
+                'Direct installs do not support the :upgrade action')
+        when :repo
+          include_recipe "yum-chef::#{new_resource.channel}"
+          package 'chefdk' do
+            version new_resource.version unless new_resource.version.nil?
+            action :upgrade
+          end
+        else
+          raise(Chef::Exceptions::UnsupportedAction,
+                'Custom installs do not support the :upgrade action')
+        end
+      end
+
+      #
       # The YUM repository is shared between Chef, Chef-DK, etc. so all we can
       # confidently do for removal is to remove the package.
       #

--- a/libraries/resource_chef_dk_app_windows.rb
+++ b/libraries/resource_chef_dk_app_windows.rb
@@ -58,6 +58,27 @@ class Chef
       end
 
       #
+      # Upgrade or install the Chef-DK. This action currently only supports the
+      # :repo installation source.
+      #
+      action :upgrade do
+        case new_resource.source
+        when :direct
+          raise(Chef::Exceptions::UnsupportedAction,
+                'Direct installs do not support the :upgrade action')
+        when :repo
+          include_recipe 'chocolatey'
+          chocolatey_package 'chefdk' do
+            version new_resource.version unless new_resource.version.nil?
+            action :upgrade
+          end
+        else
+          raise(Chef::Exceptions::UnsupportedAction,
+                'Custom installs do not support the :upgrade action')
+        end
+      end
+
+      #
       # Remove the Chef-DK Windows package.
       #
       action :remove do

--- a/spec/resources/chef_dk_app.rb
+++ b/spec/resources/chef_dk_app.rb
@@ -32,6 +32,28 @@ shared_context 'resources::chef_dk_app' do
     end
   end
 
+  shared_context 'the :upgrade action' do
+    let(:action) { :upgrade }
+
+    before(:each) do
+      allow(Kernel).to receive(:load).and_call_original
+      allow(Kernel).to receive(:load)
+        .with(%r{chef-dk/libraries/helpers\.rb}).and_return(true)
+      allow(ChefDk::Helpers).to receive(:metadata_for).with(
+        channel: channel || :stable,
+        version: version || 'latest',
+        platform: platform,
+        platform_version: /#{platform_version}.*/,
+        machine: 'x86_64'
+      ).and_return(
+        sha1: 'abcd',
+        sha256: '1234',
+        url: "http://example.com/#{channel || 'stable'}/chefdk",
+        version: version || '1.2.3'
+      )
+    end
+  end
+
   shared_context 'the :remove action' do
     let(:action) { :remove }
   end

--- a/spec/resources/chef_dk_app/debian.rb
+++ b/spec/resources/chef_dk_app/debian.rb
@@ -104,6 +104,96 @@ shared_context 'resources::chef_dk_app::debian' do
       end
     end
 
+    context 'the :upgrade action' do
+      include_context description
+
+      context 'the default source (:direct)' do
+        include_context description
+
+        shared_examples_for 'any property set' do
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+
+        [
+          'all default properties',
+          'an overridden channel property',
+          'an overridden version property'
+        ].each do |c|
+          context c do
+            include_context description
+
+            it_behaves_like 'any property set'
+          end
+        end
+      end
+
+      context 'the :repo source' do
+        include_context description
+
+        shared_examples_for 'any property set' do
+          it 'ensures apt-transport-https is installed' do
+            expect(chef_run).to install_package('apt-transport-https')
+          end
+
+          it 'configures the Chef APT repo' do
+            expect(chef_run).to include_recipe(
+              "apt-chef::#{channel || 'stable'}"
+            )
+          end
+
+          it 'upgrades the chefdk package' do
+            expect(chef_run).to upgrade_package('chefdk').with(version: version)
+          end
+        end
+
+        [
+          'all default properties',
+          'an overridden channel property',
+          'an overridden version property'
+        ].each do |c|
+          context c do
+            include_context description
+
+            it_behaves_like 'any property set'
+          end
+        end
+      end
+
+      context 'a custom source' do
+        include_context description
+
+        context 'all default properties' do
+          include_context description
+
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+
+        context 'an overridden channel property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+
+        context 'an overridden version property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+      end
+    end
+
     context 'the :remove action' do
       include_context description
 

--- a/spec/resources/chef_dk_app/rhel.rb
+++ b/spec/resources/chef_dk_app/rhel.rb
@@ -100,6 +100,92 @@ shared_context 'resources::chef_dk_app::rhel' do
       end
     end
 
+    context 'the :upgrade action' do
+      include_context description
+
+      context 'the default source (:direct)' do
+        include_context description
+
+        shared_examples_for 'any property set' do
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+
+        [
+          'all default properties',
+          'an overridden channel property',
+          'an overridden version property'
+        ].each do |c|
+          context c do
+            include_context description
+
+            it_behaves_like 'any property set'
+          end
+        end
+      end
+
+      context 'the :repo source' do
+        include_context description
+
+        shared_examples_for 'any property set' do
+          it 'configures the Chef YUM repo' do
+            expect(chef_run).to include_recipe(
+              "yum-chef::#{channel || 'stable'}"
+            )
+          end
+
+          it 'upgrades the chefdk package' do
+            expect(chef_run).to upgrade_package('chefdk').with(version: version)
+          end
+        end
+
+        [
+          'all default properties',
+          'an overridden channel property',
+          'an overridden version property'
+        ].each do |c|
+          context c do
+            include_context description
+
+            it_behaves_like 'any property set'
+          end
+        end
+      end
+
+      context 'a custom source' do
+        include_context description
+
+        context 'all default properties' do
+          include_context description
+
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+
+        context 'an overridden channel property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+
+        context 'an overridden version property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+      end
+    end
+
     context 'the :remove action' do
       include_context description
 

--- a/spec/resources/chef_dk_app/windows.rb
+++ b/spec/resources/chef_dk_app/windows.rb
@@ -105,6 +105,100 @@ shared_context 'resources::chef_dk_app::windows' do
       end
     end
 
+    context 'the :upgrade action' do
+      include_context description
+
+      context 'the default source (:direct)' do
+        include_context description
+
+        shared_examples_for 'any property set' do
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+
+        [
+          'all default properties',
+          'an overridden channel property',
+          'an overridden version property'
+        ].each do |c|
+          context c do
+            include_context description
+
+            it_behaves_like 'any property set'
+          end
+        end
+      end
+
+      context 'the :repo source' do
+        include_context description
+
+        before(:each) do
+          allow_any_instance_of(Chef::Resource)
+            .to receive(:chocolatey_installed?).and_return(false)
+        end
+
+        [
+          'all default properties',
+          'an overridden version property'
+        ].each do |c|
+          context c do
+            include_context description
+
+            it 'ensures Chocolatey is installed' do
+              expect(chef_run).to include_recipe('chocolatey')
+            end
+
+            it 'installs the chefdk Chocolatey package' do
+              expect(chef_run).to upgrade_chocolatey_package('chefdk')
+                .with(version: version && [version])
+            end
+          end
+        end
+
+        context 'an overridden channel property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(false).to eq(true)
+          end
+        end
+      end
+
+      context 'a custom source' do
+        include_context description
+
+        context 'all default properties' do
+          include_context description
+
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+
+        context 'an overridden channel property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+
+        context 'an overridden version property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+      end
+    end
+
     context 'the :remove action' do
       include_context description
 


### PR DESCRIPTION
The :repo source will be the easiest to implement this for. Except for
OS X, where the homebrew_cask resource does not have an :upgrade action.