### PR TITLE
Wrap non-repo installs in installed state checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Properties:
 
 | Property | Default    | Description                                         |
 |----------|------------|-----------------------------------------------------|
-| version  | `nil`      | Optionally install a specific version               |
+| version  | `'latest'` | Optionally install a specific version               |
 | channel  | `:stable`  | Use the `:stable` or `:current` channel             |
 | source   | `:direct`  | Install vi Omnitruck (`:direct`), a `:repo`, or URL |
 | checksum | `nil`      | Optional checksum of a custom source package        |

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -71,11 +71,11 @@ module ChefDk
       #
       # Determine whether string is a valid package version
       #
-      # @param [String] arg
+      # @param [String, NilClass] arg
       # @return [TrueClass, FalseClass]
       #
       def valid_version?(arg)
-        return true if arg == 'latest'
+        return true if arg == false || arg == 'latest'
         arg =~ /^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$/ ? true : false
       end
     end

--- a/libraries/resource_chef_dk_app.rb
+++ b/libraries/resource_chef_dk_app.rb
@@ -34,7 +34,7 @@ class Chef
       # The version of Chef-DK to install.
       #
       property :version,
-               String,
+               [String, FalseClass],
                default: 'latest',
                callbacks: {
                  'Invalid version string' =>
@@ -72,23 +72,26 @@ class Chef
       #
       property :checksum, String
 
-      declare_action_class.class_eval do
-        #
-        # Return the package metadata for the current node and new_resource.
-        # Note that `nil` will be returned of an override `source` was set to
-        # use instead of the Omnitruck API.
-        #
-        # @return [Hash,NilClass] package metadata from the Omnitruck API
-        #
-        def package_metadata
-          @package_metadata ||= ::ChefDk::Helpers.metadata_for(
-            channel: new_resource.channel,
-            version: new_resource.version,
-            platform: node['platform'],
-            platform_version: node['platform_version'],
-            machine: node['kernel']['machine']
-          )
-        end
+      #
+      # Keep a property to track the installed state of the Chef-DK.
+      #
+      property :installed, [TrueClass, FalseClass]
+
+      #
+      # Return the package metadata for the current node and new_resource.
+      # Note that `nil` will be returned of an override `source` was set to
+      # use instead of the Omnitruck API.
+      #
+      # @return [Hash,NilClass] package metadata from the Omnitruck API
+      #
+      def package_metadata
+        @package_metadata ||= ::ChefDk::Helpers.metadata_for(
+          channel: channel,
+          version: version,
+          platform: node['platform'],
+          platform_version: node['platform_version'],
+          machine: node['kernel']['machine']
+        )
       end
     end
   end

--- a/libraries/resource_chef_dk_app.rb
+++ b/libraries/resource_chef_dk_app.rb
@@ -78,6 +78,16 @@ class Chef
       property :installed, [TrueClass, FalseClass]
 
       #
+      # The current value is determined by calling the `installed_version`
+      # method, which must be defined in each sub-provider, depending on the
+      # platform.
+      #
+      load_current_value do
+        version(installed_version)
+        installed(version == false ? false : true)
+      end
+
+      #
       # Return the package metadata for the current node and new_resource.
       # Note that `nil` will be returned of an override `source` was set to
       # use instead of the Omnitruck API.
@@ -92,6 +102,19 @@ class Chef
           platform_version: node['platform_version'],
           machine: node['kernel']['machine']
         )
+      end
+
+      #
+      # The `installed_version` method much be defined by each sub-provider.
+      #
+      # @return [String, FalseClass] "major.minor.patch", "latest", or false
+      #
+      # @raise [NotImplementedError] if not defined for this provider
+      #
+      def installed_version
+        raise(NotImplementedError,
+              'The `installed_version` method must be implemented for the ' \
+              "`#{self.class}` provider")
       end
     end
   end

--- a/libraries/resource_chef_dk_app.rb
+++ b/libraries/resource_chef_dk_app.rb
@@ -35,6 +35,7 @@ class Chef
       #
       property :version,
                String,
+               default: 'latest',
                callbacks: {
                  'Invalid version string' =>
                    ->(a) { ::ChefDk::Helpers.valid_version?(a) }
@@ -82,7 +83,7 @@ class Chef
         def package_metadata
           @package_metadata ||= ::ChefDk::Helpers.metadata_for(
             channel: new_resource.channel,
-            version: new_resource.version || 'latest',
+            version: new_resource.version,
             platform: node['platform'],
             platform_version: node['platform_version'],
             machine: node['kernel']['machine']

--- a/libraries/resource_chef_dk_app_debian.rb
+++ b/libraries/resource_chef_dk_app_debian.rb
@@ -48,7 +48,7 @@ class Chef
           package 'apt-transport-https'
           include_recipe "apt-chef::#{new_resource.channel}"
           package 'chefdk' do
-            version new_resource.version unless new_resource.version.nil?
+            version new_resource.version unless new_resource.version == 'latest'
           end
         else
           local_path = ::File.join(Chef::Config[:file_cache_path],
@@ -74,7 +74,7 @@ class Chef
           package 'apt-transport-https'
           include_recipe "apt-chef::#{new_resource.channel}"
           package 'chefdk' do
-            version new_resource.version unless new_resource.version.nil?
+            version new_resource.version unless new_resource.version == 'latest'
             action :upgrade
           end
         else

--- a/libraries/resource_chef_dk_app_debian.rb
+++ b/libraries/resource_chef_dk_app_debian.rb
@@ -31,14 +31,6 @@ class Chef
       provides :chef_dk_app, platform_family: 'debian'
 
       #
-      # Determine whether the package is currently installed.
-      #
-      load_current_value do
-        version(installed_version)
-        installed(version == false ? false : true)
-      end
-
-      #
       # Depending on the specified source, download and install Chef-DK based
       # on the Omnitruck API, configure and install it from APT, or install it
       # from a custom source.
@@ -109,11 +101,10 @@ class Chef
       end
 
       #
-      # Find and return the version of the package currently installed. The
-      # Omnitruck API does not return a build number as a part of its version
-      # string, so strip that off here as well.
+      # Use Chef's Package resource and Dpkg provider to find the currently
+      # installed version.
       #
-      # @return [String, FalseClass] "major.minor.patch", "latest", or false
+      # (see Chef::Resource::ChefDkApp#installed_version)
       #
       def installed_version
         res = Chef::Resource::Package.new('chefdk', run_context)

--- a/libraries/resource_chef_dk_app_rhel.rb
+++ b/libraries/resource_chef_dk_app_rhel.rb
@@ -107,11 +107,12 @@ class Chef
       end
 
       #
-      # Find and return the version of the package currently installed. The
-      # Omnitruck API does not return a build number as part of its version
-      # string, so strip that off here as well.
+      # Use Chef's Package resource and Yum provider to find the currently
+      # installed version. We need to use Yum instead of Rpm here because the
+      # Rpm provider won't check for a version if no source property is
+      # offered.
       #
-      # @return [String, FalseClass] "major.minor.patch", "latest", or false
+      # (see Chef::Resource::ChefDkApp#installed_version)
       #
       def installed_version
         res = Chef::Resource::Package.new('chefdk', run_context)

--- a/libraries/resource_chef_dk_app_rhel.rb
+++ b/libraries/resource_chef_dk_app_rhel.rb
@@ -48,7 +48,7 @@ class Chef
         when :repo
           include_recipe "yum-chef::#{new_resource.channel}"
           package 'chefdk' do
-            version new_resource.version unless new_resource.version.nil?
+            version new_resource.version unless new_resource.version == 'latest'
           end
         else
           local_path = ::File.join(Chef::Config[:file_cache_path],
@@ -73,7 +73,7 @@ class Chef
         when :repo
           include_recipe "yum-chef::#{new_resource.channel}"
           package 'chefdk' do
-            version new_resource.version unless new_resource.version.nil?
+            version new_resource.version unless new_resource.version == 'latest'
             action :upgrade
           end
         else

--- a/libraries/resource_chef_dk_app_windows.rb
+++ b/libraries/resource_chef_dk_app_windows.rb
@@ -38,7 +38,11 @@ class Chef
       action :install do
         case new_resource.source
         when :direct
-          ver = new_resource.version || package_metadata[:version]
+          ver = if new_resource.version == 'latest'
+                  package_metadata[:version]
+                else
+                  new_resource.version
+                end
           package "Chef Development Kit v#{ver}" do
             source package_metadata[:url]
             checksum package_metadata[:sha256]
@@ -46,10 +50,14 @@ class Chef
         when :repo
           include_recipe 'chocolatey'
           chocolatey_package 'chefdk' do
-            version new_resource.version unless new_resource.version.nil?
+            version new_resource.version unless new_resource.version == 'latest'
           end
         else
-          ver = new_resource.version || package_metadata[:version]
+          ver = if new_resource.version == 'latest'
+                  package_metadata[:version]
+                else
+                  new_resource.version
+                end
           package "Chef Development Kit v#{ver}" do
             source new_resource.source.to_s
             checksum new_resource.checksum unless new_resource.checksum.nil?
@@ -69,7 +77,7 @@ class Chef
         when :repo
           include_recipe 'chocolatey'
           chocolatey_package 'chefdk' do
-            version new_resource.version unless new_resource.version.nil?
+            version new_resource.version unless new_resource.version == 'latest'
             action :upgrade
           end
         else

--- a/spec/resources/chef_dk_app.rb
+++ b/spec/resources/chef_dk_app.rb
@@ -12,6 +12,8 @@ shared_context 'resources::chef_dk_app' do
   end
   let(:name) { 'default' }
 
+  let(:installed_version) { nil }
+
   shared_context 'the default action (:install)' do
     before(:each) do
       allow(Kernel).to receive(:load).and_call_original
@@ -80,5 +82,13 @@ shared_context 'resources::chef_dk_app' do
 
   shared_context 'an overridden version property' do
     let(:version) { '4.5.6' }
+  end
+
+  shared_context 'the latest version already installed' do
+    let(:installed_version) { '1.2.3' }
+  end
+
+  shared_context 'an older version already installed' do
+    let(:installed_version) { '0.1.2' }
   end
 end

--- a/spec/resources/chef_dk_app/debian.rb
+++ b/spec/resources/chef_dk_app/debian.rb
@@ -31,7 +31,7 @@ shared_context 'resources::chef_dk_app::debian' do
           end
         end
 
-        shared_examples_for 'does not install chef-dk' do
+        shared_examples_for 'does not install Chef-DK' do
           it 'does not download the correct Chef-DK' do
             expect(chef_run).to_not create_remote_file('/tmp/cache/chefdk')
           end
@@ -56,13 +56,13 @@ shared_context 'resources::chef_dk_app::debian' do
         context 'the latest version already installed' do
           let(:installed_version) { '1.2.3' }
 
-          it_behaves_like 'does not install chef-dk'
+          it_behaves_like 'does not install Chef-DK'
         end
 
         context 'an older version already installed' do
           let(:installed_version) { '0.1.2' }
 
-          it_behaves_like 'does not install chef-dk'
+          it_behaves_like 'does not install Chef-DK'
         end
       end
 

--- a/spec/resources/chef_dk_app/debian.rb
+++ b/spec/resources/chef_dk_app/debian.rb
@@ -4,8 +4,6 @@ require_relative '../chef_dk_app'
 shared_context 'resources::chef_dk_app::debian' do
   include_context 'resources::chef_dk_app'
 
-  let(:installed_version) { nil }
-
   before(:each) do
     allow_any_instance_of(Chef::Provider::Package::Dpkg)
       .to receive(:load_current_resource)
@@ -54,13 +52,13 @@ shared_context 'resources::chef_dk_app::debian' do
         end
 
         context 'the latest version already installed' do
-          let(:installed_version) { '1.2.3' }
+          include_context description
 
           it_behaves_like 'does not install Chef-DK'
         end
 
         context 'an older version already installed' do
-          let(:installed_version) { '0.1.2' }
+          include_context description
 
           it_behaves_like 'does not install Chef-DK'
         end
@@ -101,7 +99,7 @@ shared_context 'resources::chef_dk_app::debian' do
       context 'a custom source' do
         include_context description
 
-        shared_examples_for 'does not install chef-dk' do
+        shared_examples_for 'does not install Chef-DK' do
           it 'does not download the correct Chef-DK' do
             expect(chef_run).to_not create_remote_file('/tmp/cache/chefdk')
           end
@@ -143,15 +141,15 @@ shared_context 'resources::chef_dk_app::debian' do
         end
 
         context 'the latest version already installed' do
-          let(:installed_version) { '1.2.3' }
+          include_context description
 
-          it_behaves_like 'does not install chef-dk'
+          it_behaves_like 'does not install Chef-DK'
         end
 
         context 'an older version already installed' do
-          let(:installed_version) { '0.1.2' }
+          include_context description
 
-          it_behaves_like 'does not install chef-dk'
+          it_behaves_like 'does not install Chef-DK'
         end
       end
     end

--- a/spec/resources/chef_dk_app/debian.rb
+++ b/spec/resources/chef_dk_app/debian.rb
@@ -4,6 +4,14 @@ require_relative '../chef_dk_app'
 shared_context 'resources::chef_dk_app::debian' do
   include_context 'resources::chef_dk_app'
 
+  let(:installed_version) { nil }
+
+  before(:each) do
+    allow_any_instance_of(Chef::Provider::Package::Dpkg)
+      .to receive(:load_current_resource)
+      .and_return(double(version: [installed_version]))
+  end
+
   shared_examples_for 'any Debian platform' do
     context 'the default action (:install)' do
       include_context description
@@ -11,7 +19,7 @@ shared_context 'resources::chef_dk_app::debian' do
       context 'the default source (:direct)' do
         include_context description
 
-        shared_examples_for 'any property set' do
+        shared_examples_for 'installs Chef-DK' do
           it 'downloads the correct Chef-DK' do
             expect(chef_run).to create_remote_file('/tmp/cache/chefdk')
               .with(source: "http://example.com/#{channel || 'stable'}/chefdk",
@@ -23,6 +31,16 @@ shared_context 'resources::chef_dk_app::debian' do
           end
         end
 
+        shared_examples_for 'does not install chef-dk' do
+          it 'does not download the correct Chef-DK' do
+            expect(chef_run).to_not create_remote_file('/tmp/cache/chefdk')
+          end
+
+          it 'does not install the downloaded package' do
+            expect(chef_run).to_not install_dpkg_package('/tmp/cache/chefdk')
+          end
+        end
+
         [
           'all default properties',
           'an overridden channel property',
@@ -31,8 +49,20 @@ shared_context 'resources::chef_dk_app::debian' do
           context c do
             include_context description
 
-            it_behaves_like 'any property set'
+            it_behaves_like 'installs Chef-DK'
           end
+        end
+
+        context 'the latest version already installed' do
+          let(:installed_version) { '1.2.3' }
+
+          it_behaves_like 'does not install chef-dk'
+        end
+
+        context 'an older version already installed' do
+          let(:installed_version) { '0.1.2' }
+
+          it_behaves_like 'does not install chef-dk'
         end
       end
 
@@ -71,6 +101,16 @@ shared_context 'resources::chef_dk_app::debian' do
       context 'a custom source' do
         include_context description
 
+        shared_examples_for 'does not install chef-dk' do
+          it 'does not download the correct Chef-DK' do
+            expect(chef_run).to_not create_remote_file('/tmp/cache/chefdk')
+          end
+
+          it 'does not install the downloaded package' do
+            expect(chef_run).to_not install_dpkg_package('/tmp/cache/chefdk')
+          end
+        end
+
         context 'all default properties' do
           include_context description
 
@@ -100,6 +140,18 @@ shared_context 'resources::chef_dk_app::debian' do
             pending
             expect(true).to eq(false)
           end
+        end
+
+        context 'the latest version already installed' do
+          let(:installed_version) { '1.2.3' }
+
+          it_behaves_like 'does not install chef-dk'
+        end
+
+        context 'an older version already installed' do
+          let(:installed_version) { '0.1.2' }
+
+          it_behaves_like 'does not install chef-dk'
         end
       end
     end

--- a/spec/resources/chef_dk_app/mac_os_x.rb
+++ b/spec/resources/chef_dk_app/mac_os_x.rb
@@ -4,6 +4,18 @@ require_relative '../chef_dk_app'
 shared_context 'resources::chef_dk_app::mac_os_x' do
   include_context 'resources::chef_dk_app'
 
+  let(:installed_version) { nil }
+
+  before(:each) do
+    allow_any_instance_of(Chef::Mixin::HomebrewUser).to receive(:new)
+      .and_return(double(find_homebrew_uid: 501))
+    allow(Etc).to receive(:getpwuid).with(501).and_return(double: 'homebrew')
+    allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out)
+      .with('pkgutil --pkg-info com.getchef.pkg.chefdk')
+      .and_return(double(exitstatus: installed_version.nil? ? 1 : 0,
+                         stdout: "test\nversion: #{installed_version}\nthings"))
+  end
+
   shared_examples_for 'any Mac OS X platform' do
     context 'the default action (:install)' do
       include_context description
@@ -11,7 +23,7 @@ shared_context 'resources::chef_dk_app::mac_os_x' do
       context 'the default source (:direct)' do
         include_context description
 
-        shared_examples_for 'any property set' do
+        shared_examples_for 'installs Chef-DK' do
           it 'installs the correct Chef-DK package' do
             expect(chef_run).to install_dmg_package('Chef Development Kit')
               .with(app: 'chefdk',
@@ -23,6 +35,12 @@ shared_context 'resources::chef_dk_app::mac_os_x' do
           end
         end
 
+        shared_examples_for 'does not install Chef-DK' do
+          it 'does not install the correct Chef-DK package' do
+            expect(chef_run).to_not install_dmg_package('Chef Development Kit')
+          end
+        end
+
         [
           'all default properties',
           'an overridden channel property',
@@ -31,8 +49,20 @@ shared_context 'resources::chef_dk_app::mac_os_x' do
           context c do
             include_context description
 
-            it_behaves_like 'any property set'
+            it_behaves_like 'installs Chef-DK'
           end
+        end
+
+        context 'the latest version already installed' do
+          include_context description
+
+          it_behaves_like 'does not install Chef-DK'
+        end
+
+        context 'an older version already installed' do
+          include_context description
+
+          it_behaves_like 'does not install Chef-DK'
         end
       end
 
@@ -77,6 +107,12 @@ shared_context 'resources::chef_dk_app::mac_os_x' do
       context 'a custom source' do
         include_context description
 
+        shared_examples_for 'does not install Chef-DK' do
+          it 'does not install the correct Chef-DK package' do
+            expect(chef_run).to_not install_dmg_package('Chef Development Kit')
+          end
+        end
+
         context 'all default properties' do
           include_context description
 
@@ -107,6 +143,18 @@ shared_context 'resources::chef_dk_app::mac_os_x' do
             pending
             expect(true).to eq(false)
           end
+        end
+
+        context 'the latest version already installed' do
+          include_context description
+
+          it_behaves_like 'does not install Chef-DK'
+        end
+
+        context 'an older version already installed' do
+          include_context description
+
+          it_behaves_like 'does not install Chef-DK'
         end
       end
     end

--- a/spec/resources/chef_dk_app/mac_os_x.rb
+++ b/spec/resources/chef_dk_app/mac_os_x.rb
@@ -7,9 +7,10 @@ shared_context 'resources::chef_dk_app::mac_os_x' do
   let(:installed_version) { nil }
 
   before(:each) do
-    allow_any_instance_of(Chef::Mixin::HomebrewUser).to receive(:new)
-      .and_return(double(find_homebrew_uid: 501))
-    allow(Etc).to receive(:getpwuid).with(501).and_return(double: 'homebrew')
+    allow_any_instance_of(Chef::Recipe).to receive(:homebrew_owner)
+      .and_return('test')
+    allow_any_instance_of(Chef::Resource).to receive(:homebrew_owner)
+      .and_return('test')
     allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out)
       .and_call_original
     allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out)

--- a/spec/resources/chef_dk_app/mac_os_x.rb
+++ b/spec/resources/chef_dk_app/mac_os_x.rb
@@ -11,6 +11,8 @@ shared_context 'resources::chef_dk_app::mac_os_x' do
       .and_return(double(find_homebrew_uid: 501))
     allow(Etc).to receive(:getpwuid).with(501).and_return(double: 'homebrew')
     allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out)
+      .and_call_original
+    allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out)
       .with('pkgutil --pkg-info com.getchef.pkg.chefdk')
       .and_return(double(exitstatus: installed_version.nil? ? 1 : 0,
                          stdout: "test\nversion: #{installed_version}\nthings"))

--- a/spec/resources/chef_dk_app/rhel.rb
+++ b/spec/resources/chef_dk_app/rhel.rb
@@ -4,8 +4,6 @@ require_relative '../chef_dk_app'
 shared_context 'resources::chef_dk_app::rhel' do
   include_context 'resources::chef_dk_app'
 
-  let(:installed_version) { nil }
-
   before(:each) do
     allow_any_instance_of(Chef::Provider::Package::Yum)
       .to receive(:load_current_resource)
@@ -54,13 +52,13 @@ shared_context 'resources::chef_dk_app::rhel' do
         end
 
         context 'the latest version already installed' do
-          let(:installed_version) { '1.2.3' }
+          include_context description
 
           it_behaves_like 'does not install Chef-DK'
         end
 
         context 'an older version already installed' do
-          let(:installed_version) { '0.1.2' }
+          include_context description
 
           it_behaves_like 'does not install Chef-DK'
         end

--- a/spec/resources/chef_dk_app/rhel.rb
+++ b/spec/resources/chef_dk_app/rhel.rb
@@ -5,9 +5,12 @@ shared_context 'resources::chef_dk_app::rhel' do
   include_context 'resources::chef_dk_app'
 
   before(:each) do
-    allow_any_instance_of(Chef::Provider::Package::Yum)
-      .to receive(:load_current_resource)
-      .and_return(double(version: installed_version))
+    allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out)
+      .with('rpm -q --info chefdk').and_return(
+        double(exitstatus: installed_version.nil? ? 1 : 0,
+               stdout: "Name        : chefdk\nVersion     : 0.17.17\n" \
+                       "Release     : 1.el7\n")
+      )
   end
 
   shared_examples_for 'any RHEL platform' do


### PR DESCRIPTION
With code to find the currently installed version on each supported platform. This will allow implementation of upgrade actions for non-repo installs and keep non-repo installs from re-downloading package files if they don't need to install anything.