### PR TITLE
Implement the :upgrade action for the :direct source on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased
 * Replace `:prerelease` and `:nightlies` with a `:channel` property
 * Remove dependency on the Omnijack gem
 * Rename the `package_url` attribute to `source`
+* Implement an :upgrade action for :direct and :repo package sources
 
 v3.1.0 (2015-06-03)
 -------------------

--- a/libraries/resource_chef_dk_app_mac_os_x.rb
+++ b/libraries/resource_chef_dk_app_mac_os_x.rb
@@ -75,6 +75,36 @@ class Chef
       end
 
       #
+      # Upgrade or install the Chef-DK. There is no upgrade action for the
+      # homebrew_cask resource, so only :direct installations are currently
+      # supported.
+      #
+      action :upgrade do
+        case new_resource.source
+        when :direct
+          new_resource.installed(true)
+          new_resource.version('latest')
+
+          converge_if_changed :installed, :version do
+            dmg_package 'Chef Development Kit' do
+              app ::File.basename(package_metadata[:url], '.dmg')
+              volumes_dir 'Chef Development Kit'
+              source package_metadata[:url]
+              type 'pkg'
+              package_id 'com.getchef.pkg.chefdk'
+              checksum package_metadata[:sha256]
+            end
+          end
+        when :repo
+          raise(Chef::Exceptions::UnsupportedAction,
+                'Repo installs do not support the :upgrade action')
+        else
+          raise(Chef::Exceptions::UnsupportedAction,
+                'Custom installs do not support the :upgrade action')
+        end
+      end
+
+      #
       # Clean up the package directories and forget the Chef-DK entry in
       # pkgutil.
       #

--- a/libraries/resource_chef_dk_app_rhel.rb
+++ b/libraries/resource_chef_dk_app_rhel.rb
@@ -87,8 +87,18 @@ class Chef
       action :upgrade do
         case new_resource.source
         when :direct
-          raise(Chef::Exceptions::UnsupportedAction,
-                'Direct installs do not support the :upgrade action')
+          new_resource.installed(true)
+          new_resource.version('latest')
+
+          converge_if_changed :installed, :version do
+            local_path = ::File.join(Chef::Config[:file_cache_path],
+                                     ::File.basename(package_metadata[:url]))
+            remote_file local_path do
+              source package_metadata[:url]
+              checksum package_metadata[:sha256]
+            end
+            rpm_package local_path
+          end
         when :repo
           include_recipe "yum-chef::#{new_resource.channel}"
           package 'chefdk' do

--- a/spec/resources/chef_dk_app/debian.rb
+++ b/spec/resources/chef_dk_app/debian.rb
@@ -160,23 +160,58 @@ shared_context 'resources::chef_dk_app::debian' do
       context 'the default source (:direct)' do
         include_context description
 
-        shared_examples_for 'any property set' do
-          it 'raises an error' do
-            expect { chef_run }
-              .to raise_error(Chef::Exceptions::UnsupportedAction)
+        shared_examples_for 'upgrades Chef-DK' do
+          it 'downloads the correct Chef-DK' do
+            expect(chef_run).to create_remote_file('/tmp/cache/chefdk')
+              .with(source: "http://example.com/#{channel || 'stable'}/chefdk",
+                    checksum: '1234')
+          end
+
+          it 'installs the downloaded package' do
+            expect(chef_run).to install_dpkg_package('/tmp/cache/chefdk')
+          end
+        end
+
+        shared_examples_for 'does not upgrade Chef-DK' do
+          it 'does not download the correct Chef-DK' do
+            expect(chef_run).to_not create_remote_file('/tmp/cache/chefdk')
+          end
+
+          it 'does not install the downloaded package' do
+            expect(chef_run).to_not install_dpkg_package('/tmp/cache/chefdk')
           end
         end
 
         [
           'all default properties',
-          'an overridden channel property',
-          'an overridden version property'
+          'an overridden channel property'
         ].each do |c|
           context c do
             include_context description
 
-            it_behaves_like 'any property set'
+            it_behaves_like 'upgrades Chef-DK'
           end
+        end
+
+        context 'an overridden version property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+
+        context 'the latest version already installed' do
+          include_context description
+
+          it_behaves_like 'does not upgrade Chef-DK'
+        end
+
+        context 'an older version already installed' do
+          include_context description
+
+          it_behaves_like 'upgrades Chef-DK'
         end
       end
 
@@ -201,13 +236,21 @@ shared_context 'resources::chef_dk_app::debian' do
 
         [
           'all default properties',
-          'an overridden channel property',
-          'an overridden version property'
+          'an overridden channel property'
         ].each do |c|
           context c do
             include_context description
 
             it_behaves_like 'any property set'
+          end
+        end
+
+        context 'an overridden version property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
           end
         end
       end

--- a/spec/resources/chef_dk_app/mac_os_x.rb
+++ b/spec/resources/chef_dk_app/mac_os_x.rb
@@ -162,6 +162,130 @@ shared_context 'resources::chef_dk_app::mac_os_x' do
       end
     end
 
+    context 'the :upgrade action' do
+      include_context description
+
+      context 'the default source (:direct)' do
+        include_context description
+
+        shared_examples_for 'upgrades Chef-DK' do
+          it 'installs the correct Chef-DK package' do
+            expect(chef_run).to install_dmg_package('Chef Development Kit')
+              .with(app: 'chefdk',
+                    volumes_dir: 'Chef Development Kit',
+                    source: "http://example.com/#{channel || 'stable'}/chefdk",
+                    type: 'pkg',
+                    package_id: 'com.getchef.pkg.chefdk',
+                    checksum: '1234')
+          end
+        end
+
+        shared_examples_for 'does not upgrade Chef-DK' do
+          it 'does not install the correct Chef-DK package' do
+            expect(chef_run).to_not install_dmg_package('Chef Development Kit')
+          end
+        end
+
+        [
+          'all default properties',
+          'an overridden channel property'
+        ].each do |c|
+          context c do
+            include_context description
+
+            it_behaves_like 'upgrades Chef-DK'
+          end
+        end
+
+        context 'an overridden version property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+
+        context 'the latest version already installed' do
+          include_context description
+
+          it_behaves_like 'does not upgrade Chef-DK'
+        end
+
+        context 'an older version already installed' do
+          include_context description
+
+          it_behaves_like 'upgrades Chef-DK'
+        end
+      end
+
+      context 'the :repo source' do
+        include_context description
+
+        before(:each) do
+          stub_command('which git').and_return('/usr/bin/git')
+        end
+
+        context 'all default properties' do
+          include_context description
+
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+
+        context 'an overridden version property' do
+          include_context description
+
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+
+        context 'an overridden channel property' do
+          include_context description
+
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+      end
+
+      context 'a custom source' do
+        include_context description
+
+        context 'all default properties' do
+          include_context description
+
+          it 'raises an error' do
+            expect { chef_run }
+              .to raise_error(Chef::Exceptions::UnsupportedAction)
+          end
+        end
+
+        context 'an overridden channel property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+
+        context 'an overridden version property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+      end
+    end
+
     context 'the :remove action' do
       include_context description
 

--- a/spec/resources/chef_dk_app/windows.rb
+++ b/spec/resources/chef_dk_app/windows.rb
@@ -171,23 +171,53 @@ shared_context 'resources::chef_dk_app::windows' do
       context 'the default source (:direct)' do
         include_context description
 
-        shared_examples_for 'any property set' do
-          it 'raises an error' do
-            expect { chef_run }
-              .to raise_error(Chef::Exceptions::UnsupportedAction)
+        shared_examples_for 'upgrades Chef-DK' do
+          it 'installs the correct Chef-DK package' do
+            pkg = 'Chef Development Kit v1.2.3'
+            expect(chef_run).to install_package(pkg).with(
+              source: "http://example.com/#{channel || 'stable'}/chefdk",
+              checksum: '1234'
+            )
+          end
+        end
+
+        shared_examples_for 'does not upgrade Chef-DK' do
+          it 'does not install the correct Chef-DK package' do
+            pkg = 'Chef Development Kit v1.2.3'
+            expect(chef_run).to_not install_package(pkg)
           end
         end
 
         [
           'all default properties',
-          'an overridden channel property',
-          'an overridden version property'
+          'an overridden channel property'
         ].each do |c|
           context c do
             include_context description
 
-            it_behaves_like 'any property set'
+            it_behaves_like 'upgrades Chef-DK'
           end
+        end
+
+        context 'an overridden version property' do
+          include_context description
+
+          it 'raises an error' do
+            pending
+            expect(true).to eq(false)
+          end
+        end
+
+        context 'the latest version already installed' do
+          include_context description
+
+          it_behaves_like 'does not upgrade Chef-DK'
+        end
+
+        context 'an older version already installed' do
+          include_context description
+
+          it_behaves_like 'upgrades Chef-DK'
         end
       end
 


### PR DESCRIPTION
Still not sure what to do if the version property is overridden for an :upgrade action :\

Right now it would ignore the version property. It should probably either respect it or raise an error. Unit tests for it to raise an error are left in pending for now.