### PR TITLE
DRY the chef_dk_app resource action code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Unreleased
 * Replace `:prerelease` and `:nightlies` with a `:channel` property
 * Remove dependency on the Omnijack gem
 * Rename the `package_url` attribute to `source`
-* Implement an :upgrade action for :direct and :repo package sources
+* Implement an `:upgrade` action for `:direct` and `:repo` package sources
 
 v3.1.0 (2015-06-03)
 -------------------

--- a/README.md
+++ b/README.md
@@ -137,10 +137,15 @@ Properties:
 
 Actions:
 
-| Action      | Description                   
-|-------------|-------------------------------|
-| `:install ` | Default; installs the Chef-DK |
-| `:remove`   | Uninstalls the Chef-DK        |
+| Action     | Description                   
+|------------|---------------------------------------------|
+| `:install` | Default; installs the Chef-DK               |
+| `:upgrade` | Install or upgrade to the latest Chef-DK \* |
+| `:remove`  | Uninstalls the Chef-DK                      |
+
+\* The `:upgrade` action suports the `:direct` and `:repo` sources only. It
+will always install the latest version. The use of a `version` property with it
+is not supported.
 
 ***chef_dk_gem***
 

--- a/libraries/resource_chef_dk_app.rb
+++ b/libraries/resource_chef_dk_app.rb
@@ -101,7 +101,7 @@ class Chef
         when :repo
           install_repo!
         else
-          install_custom!
+          converge_if_changed(:installed) { install_custom! }
         end
       end
 

--- a/libraries/resource_chef_dk_app.rb
+++ b/libraries/resource_chef_dk_app.rb
@@ -167,22 +167,22 @@ class Chef
                   "`#{self.class}` provider")
           end
         end
-      end
 
-      #
-      # Construct a download path in Chef's cache directory for either direct
-      # or custom package downloads. This can be useful for package resources
-      # that won't accept a remote URL as their source.
-      #
-      # @return [String] a package download path
-      #
-      def local_path
-        src = if %i(direct repo).include?(new_resource.source)
-                package_metadata[:url]
-              else
-                new_resource.source.to_s
-              end
-        ::File.join(Chef::Config[:file_cache_path], ::File.basename(src))
+        #
+        # Construct a download path in Chef's cache directory for either direct
+        # or custom package downloads. This can be useful for package resources
+        # that won't accept a remote URL as their source.
+        #
+        # @return [String] a package download path
+        #
+        def local_path
+          src = if %i(direct repo).include?(new_resource.source)
+                  package_metadata[:url]
+                else
+                  new_resource.source.to_s
+                end
+          ::File.join(Chef::Config[:file_cache_path], ::File.basename(src))
+        end
       end
 
       #

--- a/libraries/resource_chef_dk_app_debian.rb
+++ b/libraries/resource_chef_dk_app_debian.rb
@@ -95,10 +95,7 @@ class Chef
         def upgrade_repo!
           package 'apt-transport-https'
           include_recipe "apt-chef::#{new_resource.channel}"
-          package 'chefdk' do
-            version new_resource.version unless new_resource.version == 'latest'
-            action :upgrade
-          end
+          package('chefdk') { action :upgrade }
         end
 
         #

--- a/libraries/resource_chef_dk_app_debian.rb
+++ b/libraries/resource_chef_dk_app_debian.rb
@@ -30,84 +30,85 @@ class Chef
     class ChefDkAppDebian < ChefDkApp
       provides :chef_dk_app, platform_family: 'debian'
 
-      #
-      # Depending on the specified source, download and install Chef-DK based
-      # on the Omnitruck API, configure and install it from APT, or install it
-      # from a custom source.
-      #
-      action :install do
-        case new_resource.source
-        when :direct
-          new_resource.installed(true)
-
-          converge_if_changed :installed do
-            local_path = ::File.join(Chef::Config[:file_cache_path],
-                                     ::File.basename(package_metadata[:url]))
-            remote_file local_path do
-              source package_metadata[:url]
-              checksum package_metadata[:sha256]
-            end
-            dpkg_package local_path
+      action_class.class_eval do
+        #
+        # Download a .deb package file from the URL provided by the Omnitruck
+        # API and install it.
+        #
+        # (see Chef::Resource::ChefDkApp#install_direct!)
+        #
+        def install_direct!
+          remote_file local_path do
+            source package_metadata[:url]
+            checksum package_metadata[:sha256]
           end
-        when :repo
+          dpkg_package local_path
+        end
+
+        #
+        # Configure the Chef APT repository and install the Chef-DK package
+        # from there.
+        #
+        # (see Chef::Resource::ChefDkApp#install_repo!
+        #
+        def install_repo!
           package 'apt-transport-https'
           include_recipe "apt-chef::#{new_resource.channel}"
           package 'chefdk' do
             version new_resource.version unless new_resource.version == 'latest'
           end
-        else
-          new_resource.installed(true)
-
-          converge_if_changed :installed do
-            local_path = ::File.join(Chef::Config[:file_cache_path],
-                                     ::File.basename(new_resource.source.to_s))
-            remote_file local_path do
-              source new_resource.source.to_s
-              checksum new_resource.checksum unless new_resource.checksum.nil?
-            end
-            dpkg_package local_path
-          end
         end
-      end
 
-      #
-      # Upgrade or install the Chef-DK. This action currently only supports the
-      # :direct and :repo installation sources.
-      #
-      action :upgrade do
-        case new_resource.source
-        when :direct
-          new_resource.installed(true)
-          new_resource.version('latest')
-
-          converge_if_changed :installed, :version do
-            local_path = ::File.join(Chef::Config[:file_cache_path],
-                                     ::File.basename(package_metadata[:url]))
-            remote_file local_path do
-              source package_metadata[:url]
-              checksum package_metadata[:sha256]
-            end
-            dpkg_package local_path
+        #
+        # Download a .deb package file from a custom URL and install it.
+        #
+        # (see Chef::Resource::ChefDkApp#install_custom!)
+        #
+        def install_custom!
+          remote_file local_path do
+            source new_resource.source.to_s
+            checksum new_resource.checksum unless new_resource.checksum.nil?
           end
-        when :repo
+          dpkg_package local_path
+        end
+
+        #
+        # Download the latest .deb package from the Omnitruck API and install
+        # it.
+        #
+        # (see Chef::Resource::ChefDkApp#upgrade_direct!)
+        #
+        def upgrade_direct!
+          remote_file local_path do
+            source package_metadata[:url]
+            checksum package_metadata[:sha256]
+          end
+          dpkg_package local_path
+        end
+
+        #
+        # Ensure the Chef APT repo is configured and pass an :upgrade action
+        # on to a chefdk package resource.
+        #
+        # (see Chef::Resource::ChefDkApp#upgrade_repo!)
+        #
+        def upgrade_repo!
           package 'apt-transport-https'
           include_recipe "apt-chef::#{new_resource.channel}"
           package 'chefdk' do
             version new_resource.version unless new_resource.version == 'latest'
             action :upgrade
           end
-        else
-          raise(Chef::Exceptions::UnsupportedAction,
-                'Custom installs do not support the :upgrade action')
         end
-      end
 
-      #
-      # The APT repository is shared between Chef, Chef-DK, etc. so all we can
-      # confidently do for removal is to remove the package.
-      #
-      action :remove do
-        package('chefdk') { action :purge }
+        #
+        # We can't be certain that the Chef APT repo is only being used for
+        # Chef-DK, so the remove action is just a package purge regardless of
+        # installation type.
+        #
+        %w(remove_direct! remove_repo! remove_custom!).each do |m|
+          define_method(m) { package('chefdk') { action :purge } }
+        end
       end
 
       #

--- a/libraries/resource_chef_dk_app_rhel.rb
+++ b/libraries/resource_chef_dk_app_rhel.rb
@@ -96,10 +96,7 @@ class Chef
         #
         def upgrade_repo!
           include_recipe "yum-chef::#{new_resource.channel}"
-          package 'chefdk' do
-            version new_resource.version unless new_resource.version == 'latest'
-            action :upgrade
-          end
+          package('chefdk') { action :upgrade }
         end
 
         #

--- a/libraries/resource_chef_dk_app_windows.rb
+++ b/libraries/resource_chef_dk_app_windows.rb
@@ -40,12 +40,7 @@ class Chef
         # (see Chef::Resource::ChefDkApp#install_direct!)
         #
         def install_direct!
-          ver = if new_resource.version == 'latest'
-                  package_metadata[:version]
-                else
-                  new_resource.version
-                end
-          package "Chef Development Kit v#{ver}" do
+          package package_name do
             source package_metadata[:url]
             checksum package_metadata[:sha256]
           end
@@ -70,12 +65,7 @@ class Chef
         # (see Chef::Resource::ChefDkApp#install_custom!)
         #
         def install_custom!
-          ver = if new_resource.version == 'latest'
-                  package_metadata[:version]
-                else
-                  new_resource.version
-                end
-          package "Chef Development Kit v#{ver}" do
+          package package_name do
             source new_resource.source.to_s
             checksum new_resource.checksum unless new_resource.checksum.nil?
           end
@@ -145,6 +135,21 @@ class Chef
         def remove_repo!
           chocolatey_package('chefdk') { action :remove }
         end
+      end
+
+      #
+      # Determine and return the name of the Windows package. This can be
+      # tricky because the package name includes the version string.
+      #
+      # @return [String] The name for a windows_package resource
+      #
+      def package_name
+        ver = if new_resource.version == 'latest'
+                package_metadata[:version]
+              else
+                new_resource.version
+              end
+        "Chef Development Kit v#{ver}"
       end
 
       #

--- a/libraries/resource_chef_dk_app_windows.rb
+++ b/libraries/resource_chef_dk_app_windows.rb
@@ -32,102 +32,118 @@ class Chef
 
       provides :chef_dk_app, platform_family: 'windows'
 
-      #
-      # Install the Chef-DK Windows package from the appropriate source.
-      #
-      action :install do
-        case new_resource.source
-        when :direct
-          new_resource.installed(true)
-
-          converge_if_changed :installed do
-            ver = if new_resource.version == 'latest'
-                    package_metadata[:version]
-                  else
-                    new_resource.version
-                  end
-            package "Chef Development Kit v#{ver}" do
-              source package_metadata[:url]
-              checksum package_metadata[:sha256]
-            end
+      action_class.class_eval do
+        #
+        # Download a .msi package file from the URL provided by the Omnitruck
+        # API and install it.
+        #
+        # (see Chef::Resource::ChefDkApp#install_direct!)
+        #
+        def install_direct!
+          ver = if new_resource.version == 'latest'
+                  package_metadata[:version]
+                else
+                  new_resource.version
+                end
+          package "Chef Development Kit v#{ver}" do
+            source package_metadata[:url]
+            checksum package_metadata[:sha256]
           end
-        when :repo
+        end
+
+        #
+        # Ensure Chocolatey is installed and install the Chef-DK Chocolatey
+        # package.
+        #
+        # (see Chef::Resource::ChefDkApp#install_repo!)
+        #
+        def install_repo!
           include_recipe 'chocolatey'
           chocolatey_package 'chefdk' do
             version new_resource.version unless new_resource.version == 'latest'
           end
-        else
-          new_resource.installed(true)
+        end
 
-          converge_if_changed :installed do
-            ver = if new_resource.version == 'latest'
-                    package_metadata[:version]
-                  else
-                    new_resource.version
-                  end
-            package "Chef Development Kit v#{ver}" do
-              source new_resource.source.to_s
-              checksum new_resource.checksum unless new_resource.checksum.nil?
-            end
+        #
+        # Download a .msi package file from a custom URL and install it.
+        #
+        # (see Chef::Resource::ChefDkApp#install_custom!)
+        #
+        def install_custom!
+          ver = if new_resource.version == 'latest'
+                  package_metadata[:version]
+                else
+                  new_resource.version
+                end
+          package "Chef Development Kit v#{ver}" do
+            source new_resource.source.to_s
+            checksum new_resource.checksum unless new_resource.checksum.nil?
           end
         end
-      end
 
-      #
-      # Upgrade or install the Chef-DK. This action currently only supports the
-      # :repo installation source.
-      #
-      action :upgrade do
-        case new_resource.source
-        when :direct
-          new_resource.installed(true)
-          new_resource.version('latest')
-
-          converge_if_changed :installed, :version do
-            package "Chef Development Kit v#{package_metadata[:version]}" do
-              source package_metadata[:url]
-              checksum package_metadata[:sha256]
-            end
+        #
+        # Download the latest .msi package from the Omnitruck API and install
+        # it.
+        #
+        # (see Chef::Resource::ChefDkApp#upgrade_direct!)
+        #
+        def upgrade_direct!
+          package "Chef Development Kit v#{package_metadata[:version]}" do
+            source package_metadata[:url]
+            checksum package_metadata[:sha256]
           end
-        when :repo
+        end
+
+        #
+        # Ensure Chocolatey is configured and pass an :upgrade action on to
+        # a chefdk chocolatey_package resource.
+        #
+        # (see Chef::Resource::ChefDkApp#upgrade_repo!)
+        #
+        def upgrade_repo!
           include_recipe 'chocolatey'
           chocolatey_package 'chefdk' do
             version new_resource.version unless new_resource.version == 'latest'
             action :upgrade
           end
-        else
-          raise(Chef::Exceptions::UnsupportedAction,
-                'Custom installs do not support the :upgrade action')
         end
-      end
 
-      #
-      # Remove the Chef-DK Windows package.
-      #
-      action :remove do
-        case new_resource.source
-        when :repo
-          chocolatey_package('chefdk') { action :remove }
-        else
-          lines = powershell_out!('Get-WmiObject -Class win32_product').stdout
-                                                                       .lines
-          idx = lines.index do |l|
-            l.match(/^\W*Name\W+:\W+Chef Development Kit/)
-          end
-
-          if idx
-            name = lines[idx].split(':')[1].strip
-            idn = lines[idx - 1].split(':')[1].strip
-            execute "Uninstall #{name}" do
-              command "msiexec /qn /x \"#{idn}\""
+        #
+        # The removal process is the same for either a direct or custom
+        # install.
+        #
+        %w(remove_direct! remove_custom!).each do |m|
+          define_method(m) do
+            lines = powershell_out!('Get-WmiObject -Class win32_product').stdout
+                                                                         .lines
+            idx = lines.index do |l|
+              l.match(/^\W*Name\W+:\W+Chef Development Kit/)
             end
-          else
-            package('Chef Development Kit') { action :remove }
+
+            if idx
+              name = lines[idx].split(':')[1].strip
+              idn = lines[idx - 1].split(':')[1].strip
+              execute "Uninstall #{name}" do
+                command "msiexec /qn /x \"#{idn}\""
+              end
+            else
+              package('Chef Development Kit') { action :remove }
+            end
+            directory ::File.expand_path('~/AppData/Local/chefdk') do
+              recursive true
+              action :delete
+            end
           end
-          directory ::File.expand_path('~/AppData/Local/chefdk') do
-            recursive true
-            action :delete
-          end
+        end
+
+        #
+        # For Chocolatey installations, remove Chef-DK by passing a :remove
+        # action on to the underlying chocolatey_package resource.
+        #
+        # (see Chef::Resource::ChefDkApp#remove_repo!)
+        #
+        def remove_repo!
+          chocolatey_package('chefdk') { action :remove }
         end
       end
 

--- a/libraries/resource_chef_dk_app_windows.rb
+++ b/libraries/resource_chef_dk_app_windows.rb
@@ -55,7 +55,9 @@ class Chef
         def install_repo!
           include_recipe 'chocolatey'
           chocolatey_package 'chefdk' do
-            version new_resource.version unless new_resource.version == 'latest'
+            if !new_resource.version.nil? && new_resource.version != 'latest'
+              version new_resource.version
+            end
           end
         end
 
@@ -93,7 +95,6 @@ class Chef
         def upgrade_repo!
           include_recipe 'chocolatey'
           chocolatey_package 'chefdk' do
-            version new_resource.version unless new_resource.version == 'latest'
             action :upgrade
           end
         end
@@ -135,21 +136,21 @@ class Chef
         def remove_repo!
           chocolatey_package('chefdk') { action :remove }
         end
-      end
 
-      #
-      # Determine and return the name of the Windows package. This can be
-      # tricky because the package name includes the version string.
-      #
-      # @return [String] The name for a windows_package resource
-      #
-      def package_name
-        ver = if new_resource.version == 'latest'
-                package_metadata[:version]
-              else
-                new_resource.version
-              end
-        "Chef Development Kit v#{ver}"
+        #
+        # Determine and return the name of the Windows package. This can be
+        # tricky because the package name includes the version string.
+        #
+        # @return [String] The name for a windows_package resource
+        #
+        def package_name
+          ver = if new_resource.version == 'latest'
+                  package_metadata[:version]
+                else
+                  new_resource.version
+                end
+          "Chef Development Kit v#{ver}"
+        end
       end
 
       #

--- a/spec/resources/chef_dk_app/windows.rb
+++ b/spec/resources/chef_dk_app/windows.rb
@@ -242,7 +242,7 @@ shared_context 'resources::chef_dk_app::windows' do
 
             it 'installs the chefdk Chocolatey package' do
               expect(chef_run).to upgrade_chocolatey_package('chefdk')
-                .with(version: version && [version])
+                .with(version: nil)
             end
           end
         end


### PR DESCRIPTION
A lot of the boilerplate can live in the parent app class.