### PR TITLE
Add support for Amazon provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ the platform on which Chef is running.
 
 A generic provider of all non-platform-specific functionality.
 
+***Chef::Provider::ChefDk::Amazon***
+
+Provides the Amazon platform support.
+
 ***Chef::Provider::ChefDk::Debian***
 
 Provides the Ubuntu platform support.

--- a/libraries/provider_chef_dk_amazon.rb
+++ b/libraries/provider_chef_dk_amazon.rb
@@ -1,0 +1,35 @@
+# Encoding: UTF-8
+#
+# Cookbook Name:: chef-dk
+# Library:: provider_chef_dk_fedora
+#
+# Copyright 2014-2015 Jonathan Hartman
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/provider'
+require_relative 'provider_chef_dk'
+require_relative 'provider_chef_dk_rhel'
+
+class Chef
+  class Provider
+    class ChefDk < Provider
+      # A Chef-DK provider for Amazon, works exactly the same as RHEL.
+      #
+      # @author Jonathan Hartman <j@p4nt5.com>
+      class Amazon < ChefDk::Rhel
+      end
+    end
+  end
+end

--- a/libraries/resource_chef_dk.rb
+++ b/libraries/resource_chef_dk.rb
@@ -25,6 +25,7 @@ require_relative 'provider_chef_dk_mac_os_x'
 require_relative 'provider_chef_dk_rhel'
 require_relative 'provider_chef_dk_fedora'
 require_relative 'provider_chef_dk_windows'
+require_relative 'provider_chef_dk_amazon'
 
 class Chef
   class Resource

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ maintainer_email 'j@p4nt5.com'
 license          'Apache v2.0'
 description      'Installs/configures the Chef-DK'
 long_description 'Installs/configures the Chef-DK'
-version          '3.1.0'
+version          '3.1.1'
 
 depends          'dmg', '~> 2.2'
 
@@ -19,4 +19,5 @@ end
 supports         'fedora'
 supports         'mac_os_x', '>= 10.8'
 supports         'windows'
+supports         'amazon'
 # rubocop:enable SingleSpaceBeforeFirstArg

--- a/spec/libraries/provider_chef_dk_amazon_spec.rb
+++ b/spec/libraries/provider_chef_dk_amazon_spec.rb
@@ -1,0 +1,35 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+require_relative '../../libraries/provider_chef_dk_amazon'
+
+describe Chef::Provider::ChefDk::Amazon do
+  let(:platform) { {} }
+  let(:chefdk_version) { nil }
+  let(:package_url) { nil }
+  let(:new_resource) do
+    double(name: 'my_chef_dk',
+           version: chefdk_version,
+           package_url: package_url)
+  end
+  let(:provider) { described_class.new(new_resource, nil) }
+
+  before(:each) do
+    allow_any_instance_of(described_class).to receive(:node).and_return(
+      Fauxhai.mock(platform).data
+    )
+  end
+
+  describe '#package_provider_class' do
+    it 'returns Chef::Provider::Package::Rpm' do
+      expected = Chef::Provider::Package::Rpm
+      expect(provider.send(:package_provider_class)).to eq(expected)
+    end
+  end
+
+  describe '#bashrc_file' do
+    it 'returns "bashrc"' do
+      expect(provider.send(:bashrc_file)).to eq('/etc/bashrc')
+    end
+  end
+end


### PR DESCRIPTION
We've run into issues using this cookbook in our AWS environment as we upgrade from Chef 12 to Chef 13. We've been receiving this error when we try to converge:
 
`uninitialized constant Chef::Provider::ChefDk::Amazon` 

In Chef 12, the `node[platform_family]` attribute is set to `rhel`; while in Chef 13, the same attribute is `amazon`. 

This change will update the cookbook to include `Amazon` as a provider, as well as include the appropriate tests and cookbook updates.